### PR TITLE
update test manifest to work in current chrome ver

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,6 @@
+/*global chrome*/
+chrome.app.runtime.onLaunched.addListener(function() {
+  chrome.app.window.create('/tests/tests.html', {
+    id: "jsgitdiff"
+  });
+});

--- a/manifest.json
+++ b/manifest.json
@@ -4,12 +4,11 @@
   "version": "1",
   "manifest_version": 2,
   "app": {
-    "launch": {
-      "local_path": "tests/tests.html"
+    "background": {
+      "scripts": ["background.js"]
     }
   },
   "permissions": [
-    "debugger",
     "contextMenus",
     "http://*/",
     "https://*/",

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -1,5 +1,3 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" 
-                    "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
   <script src="../thirdparty/jquery-1.6.2.min.js"></script>


### PR DESCRIPTION
While this get the tests running in the current chrome, I can't actually get them to pass, with an error which I think is from test 9:

```
success api-built.js:981
GET https://github.com/maks/gittest1.git/info/refs?service=git-receive-pack 401 (Authorization Required) github.com/maks/gittest1.git/info/refs?service=git-receive-pack:1
Object {type: 201, msg: "Http authentication failed", auth: "Basic realm="GitHub""} api-built.js:975
error api-built.js:975
(anonymous function) api-built.js:986
worker.onmessage api-built.js:1005
```
